### PR TITLE
Add Resolved (JSON) button to JSON Schema tab

### DIFF
--- a/src/services/bblock.service.js
+++ b/src/services/bblock.service.js
@@ -7,7 +7,7 @@ import {sha256} from "js-sha256";
 const DEFAULT_BBLOCKS_REGISTER = 'https://opengeospatial.github.io/bblocks/register.json';
 const DEFAULT_BBLOCKS_REGISTER_MARKER = 'default';
 
-const COPY_PROPERTIES = ['local', 'register', 'importLevel']
+const COPY_PROPERTIES = ['local', 'register', 'importLevel', 'resolvedSchema']
 
 const registerPalette = createChooser();
 


### PR DESCRIPTION
## Summary

- Adds a **Resolved (JSON)** button to the JSON Schema tab's toggle group, alongside the existing Source, Full (YAML), and Full (JSON) buttons
- Displays a fully resolved, self-contained schema with all `$ref` inlined and `allOf` flattened — no external references
- Button is **conditionally rendered** — only appears when the bblock has a `resolvedSchema` URL in `register.json`

## Motivation

The existing "Full" schema views show the annotated schema from `build/annotated/`, which still contains `$ref` references to remote URLs. For building block authors and consumers who need a single self-contained JSON Schema (for local validation, JSON Forms integration, or tooling), a fully resolved view is valuable.

The `resolvedSchema` URL is injected into `register.json` by a post-processing step (e.g., a script that resolves all `$ref` and publishes the result alongside the building block sources). Repos that don't add this property are unaffected — the button simply won't appear.

## Changes

**`src/components/bblock/JsonSchemaViewer.vue`** (+46 lines):
- New `v-btn` with `v-if="bblock?.resolvedSchema"` guard and tooltip
- `resolvedJson` data state (`loading`, `contents`, `error`)
- `currentSchema` and `currentSchemaLoading` computed property cases
- Mode watcher branch that lazy-fetches via `fetchDocumentByUrl()` on first click
- Error alert and URL display bar for the resolved mode
- Existing URL bar scoped to `annotated`/`annotated-json` modes only (was previously shown for all non-source modes)

**`src/services/bblock.service.js`** (+1 word):
- Added `'resolvedSchema'` to `COPY_PROPERTIES` so the URL persists from the register entry through `fetchBBlock()`

## Live demo

Direct link to a profile's JSON Schema view, where the **Resolved (JSON)** button appears alongside Source / Full (YAML) / Full (JSON):

https://cross-domain-interoperability-framework.github.io/metadataBuildingBlocks/viewer/bblock/cdif.bbr.metadata.profiles.cdifProfiles.CDIFDiscoveryProfile/json-schema

(Any building block with a `resolvedSchema` in the register shows the button — e.g. the CDIF profiles or core types like `skosConcept`.)


🤖 Generated with [Claude Code](https://claude.com/claude-code)